### PR TITLE
Improve infeasible hints with numeric guidance

### DIFF
--- a/test_solver_iis.py
+++ b/test_solver_iis.py
@@ -63,7 +63,10 @@ def test_real_model_iis():
     assert result["infeasible"] is True
     assert "hint_ranked" in result["debug"]
     assert isinstance(result["debug"]["hint_ranked"], list)
+    assert "hint_relaxations" in result["debug"]
+    assert isinstance(result["debug"]["hint_relaxations"], dict)
     print("IIS-Based Hints:", result["debug"]["hint_ranked"])
+    print("Relaxations:", result["debug"]["hint_relaxations"])
     print("Summary:", result["debug"]["hint_summary"])
     print("Full debug:", result["debug"])
 


### PR DESCRIPTION
## Summary
- analyze infeasible models by solving an auxiliary slack LP
- provide ranked hints with numeric delta amounts
- return minimal constraint relaxations as `hint_relaxations`
- update IIS test to check for new debug fields

## Testing
- `python test_solver_iis.py` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `python -m pytest -q` *(fails: No module named pytest)*