### PR TITLE
Add relaxation fallback for infeasible LP models

### DIFF
--- a/models.py
+++ b/models.py
@@ -13,6 +13,7 @@ class LPModel(BaseModel):
     opType: Literal["min", "max"]
     constraints: Dict[str, ConstraintRange]
     variables: Dict[str, Dict[str, float]]
+    allow_relaxation: bool = False
 
 
 class LPRequest(BaseModel):


### PR DESCRIPTION
## Summary
- add `allow_relaxation` flag to `LPModel`
- implement `apply_relaxations` and recursion limit in `solve_model`
- retry solving with relaxed constraints when infeasible and permitted

## Testing
- `python -m py_compile main.py models.py solver.py utils.py`
